### PR TITLE
choco updated to version 3.3.3, resolved compilation errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     </developers>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <slf4jVersion>1.6.6</slf4jVersion>
     </properties>
 
     <scm>
@@ -50,8 +51,18 @@
         <dependency>
             <groupId>org.choco-solver</groupId>
             <artifactId>choco-solver</artifactId>
-            <version>3.3.0</version>
+            <version>3.3.3</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4jVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>${slf4jVersion}</version>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>

--- a/src/main/java/org/chocosolver/cpviz/Visualization.java
+++ b/src/main/java/org/chocosolver/cpviz/Visualization.java
@@ -76,7 +76,7 @@ import static org.chocosolver.cpviz.Show.VIZ;
  */
 
 // BEWARE: indices must start at 1
-public class Visualization implements IMonitorClose, IMonitorInitialize, IMonitorInitPropagation,
+public class Visualization implements IMonitorClose, IMonitorInitialize,
         IMonitorDownBranch, IMonitorContradiction, IMonitorSolution {
 
     private String pbid;
@@ -135,7 +135,7 @@ public class Visualization implements IMonitorClose, IMonitorInitialize, IMonito
             e.printStackTrace();
         }
         configuration.printf(CPVizConstant.C_CONF_TAG_IN, dir, pbid);
-        solver.getSearchLoop().plugSearchMonitor(this);
+        solver.plugMonitor(this);
     }
 
     /**
@@ -278,17 +278,10 @@ public class Visualization implements IMonitorClose, IMonitorInitialize, IMonito
 
     @Override
     public void beforeInitialize() {
-    }
-
-    @Override
-    public void afterInitialize() {
         node_id = 0;
         parent_id.set(0);
         state_id = 1;
-    }
 
-    @Override
-    public void beforeInitialPropagation() {
         if (tree != null) {
             tree.printf(T_ROOT_TAG);
         }
@@ -299,7 +292,7 @@ public class Visualization implements IMonitorClose, IMonitorInitialize, IMonito
     }
 
     @Override
-    public void afterInitialPropagation() {
+    public void afterInitialize() {
         if (visualization != null) {
             printVisualizerStat(state_id, 0, false, null);
         }
@@ -307,23 +300,13 @@ public class Visualization implements IMonitorClose, IMonitorInitialize, IMonito
     }
 
     @Override
-    public void beforeDownLeftBranch() {
+    public void beforeDownBranch(boolean left) {
     }
 
     @Override
-    public void afterDownLeftBranch() {
+    public void afterDownBranch(boolean left) {
         node();
     }
-
-    @Override
-    public void beforeDownRightBranch() {
-    }
-
-    @Override
-    public void afterDownRightBranch() {
-        node();
-    }
-
 
     @Override
     public void onContradiction(ContradictionException cex) {
@@ -334,7 +317,7 @@ public class Visualization implements IMonitorClose, IMonitorInitialize, IMonito
         node_id++;
         Decision currentDecision = solver.getSearchLoop().getLastDecision();
         if (tree != null) {
-            Object bo = currentDecision.getDecisionVariable();
+            Object bo = currentDecision.getDecisionVariables();
             String name = bo.toString();
             String dsize = "?";
             if (bo instanceof IntVar) {

--- a/src/main/java/org/chocosolver/cpviz/visualizers/BoolChanneling.java
+++ b/src/main/java/org/chocosolver/cpviz/visualizers/BoolChanneling.java
@@ -142,7 +142,7 @@ public final class BoolChanneling extends Visualizer {
     protected void print(boolean focus, Decision decision) {
         writer.argumentIn(Writer._1, 3).ivar(var, Writer._1, 4).argumentOut(3);
 
-        if (decision != null && decision.getDecisionVariable() == var) {
+        if (decision != null && decision.getDecisionVariables() == var) {
             if (focus) {
                 writer.focus(Writer._1 + Writer._S + Integer.toString(1), group, type);
             } else {
@@ -154,7 +154,7 @@ public final class BoolChanneling extends Visualizer {
 
         if (decision != null) {
             for (int i = 0; i < bool.length; i++) {
-                if (decision.getDecisionVariable() == bool[i]) {
+                if (decision.getDecisionVariables() == bool[i]) {
                     if (focus) {
                         writer.focus(Writer._3 + Writer._S + Integer.toString(i + 1), group, type);
                         break;

--- a/src/main/java/org/chocosolver/cpviz/visualizers/DomainMatrix.java
+++ b/src/main/java/org/chocosolver/cpviz/visualizers/DomainMatrix.java
@@ -96,7 +96,7 @@ public class DomainMatrix extends Visualizer {
         if (decision != null) {
             for (int i = 0; i < vars.length; i++) {
                 for (int j = 0; j < vars[i].length; j++) {
-                    if (decision.getDecisionVariable()== vars[i][j]) {
+                    if (decision.getDecisionVariables()== vars[i][j]) {
                         if (focus) {
                             writer.focus((i + 1) + Writer._S + (j + 1), group);
                         } else {

--- a/src/main/java/org/chocosolver/cpviz/visualizers/Element.java
+++ b/src/main/java/org/chocosolver/cpviz/visualizers/Element.java
@@ -90,7 +90,7 @@ public final class Element extends Visualizer {
     protected void print(boolean focus, Decision decision) {
         writer.argumentIn(Writer._1, 3).ivar(index, Writer._1, 4).argumentOut(3);
 
-        if (decision != null && decision.getDecisionVariable() == index) {
+        if (decision != null && decision.getDecisionVariables() == index) {
             if (focus) {
                 writer.focus(Writer._1 + Writer._S + Integer.toString(1), group, type);
             } else {
@@ -100,7 +100,7 @@ public final class Element extends Visualizer {
         writer.argumentIn(Writer._2, 3).array(values, 4).argumentOut(3);
 
         writer.argumentIn(Writer._3, 3).ivar(value, Writer._3, 4).argumentOut(3);
-        if (decision != null && decision.getDecisionVariable() == value) {
+        if (decision != null && decision.getDecisionVariables() == value) {
             if (focus) {
                 writer.focus(Writer._3 + Writer._S + Integer.toString(3), group, type);
             } else {


### PR DESCRIPTION
Hello I updated choco-cpviz to work with current version of choco solver (3.3.3). Only part that I'm not 100% sure is caused by removed IMonitorInitPropagation, the code from the methods beforeInitialPropagation() and afterInitialPropagation() had to be moved to beforeInitialize() and afterInitialize() methods.
